### PR TITLE
FileSupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Node FileSystem API
 
-Node-FSAPI provides a RESTful (CRUD) server for interacting with remote file systems. It relies on 
-GET (Read), POST (Create), PUT (Update), and DELETE (Delete) commands with a plain-language syntax. 
+Node-FSAPI provides a RESTful (CRUD) server for interacting with remote file systems. It relies on
+GET (Read), POST (Create), PUT (Update), and DELETE (Delete) commands with a plain-language syntax.
 
 ## Getting Started
 
-FSAPI provides a single-file `server.js` node controller with 2 core dependencies - [Restify](http://mcavage.github.io/node-restify) 
-and [node-fs-extra](https://github.com/jprichardson/node-fs-extra). The file contains a `config` object which allows for easy configuration.
+FSAPI provides a single-file `server.js` node controller with 2 core dependencies -
+* [Restify](http://mcavage.github.io/node-restify)
+* [node-fs-extra](https://github.com/jprichardson/node-fs-extra). The file contains a `config` object which allows for easy configuration.
+* [md5-file](https://www.npmjs.com/package/md5-file) Calculates an MD5 for the saved file.
+
+### Installation
+
+MacOS: `npm install --no-optional`
 
 ### Security
 
@@ -74,6 +80,30 @@ Requests to the server are made via RESTful methods - GET, PUT, POST and DELETE.
 
 `POST => {server}:{port}/{key}/file/{path}`
 
+
+Examples:
+
+Create an empty file:
+
+```
+curl -X POST  localhost:8080/12345/file/foo.txt
+```
+
+Create a file with a file: (MD5 hash returned for saved file)
+
+```
+$ md5 foo.txt
+MD5 (foo.txt) = 3b1340c072317b95529b826b6696c6ab
+$ curl -X POST  -F filedata=@foo.txt localhost:8080/12345/file/foo.txt
+{"status":"success","data":"3b1340c072317b95529b826b6696c6ab"}
+```
+
+Create a file with text
+
+```
+curl -X POST -F data='{"some": "text"}' localhost:8080/12345/file/foo.txt
+```
+
 **Copy Directory or File**
 
 `POST => {server}:{port}/{key}/copy/{path}`
@@ -90,9 +120,24 @@ Requests to the server are made via RESTful methods - GET, PUT, POST and DELETE.
 
 **Save Contents to File**
 
-`PUT => {server}:{port}/{key}/save/{path}`
+`PUT => {server}:{port}/{key}/file/{path}`
 
-`PUT` parameter `data` is required with the contents to be saved
+Examples:
+
+Update file with file:
+
+```
+$ md5 foo.txt
+MD5 (foo.txt) = 3b1340c072317b95529b826b6696c6ab
+$ curl -X PUT -F filedata=@foo.txt localhost:8080/12345/file/foo.txt
+{"status":"success","data":"3b1340c072317b95529b826b6696c6ab"}
+```
+Update file with text:
+
+```
+curl -X PUT -F data='{"some": "text"}' localhost:8080/12345/file/foo.txt
+{"status":"success","data":null}
+```
 
 ### DELETE
 
@@ -144,7 +189,7 @@ Initially it is important to define the connection information, which is done th
 fsapi.config("http://yourserver:port", "api-key", {OPTIONAL - Bool 'Validate'});
 ```
 
-The config process (with arguments) sets these values into localStorage (with Cookie fallback). There is a third argument `validate` which defaults to `true`. 
+The config process (with arguments) sets these values into localStorage (with Cookie fallback). There is a third argument `validate` which defaults to `true`.
 If set to `false` in the config call above the entire response from the server will be returned and must be parsed manually.
 
 Calling `fsapi.config()` without arguments will return an object with the url and key. You can change either value individually using:
@@ -204,7 +249,7 @@ The fsapi validate method is used to parse the response from the server, this me
 fsapi.validate(data);
 ```
 
-For a sucessful response this method will return boolean `true`, or in cases such as `.list()` and `.open()` will return the 
+For a sucessful response this method will return boolean `true`, or in cases such as `.list()` and `.open()` will return the
 data from the response.
 
 On error or failure, the response from `.validate()` will be boolean `false`.

--- a/component.json
+++ b/component.json
@@ -1,9 +1,10 @@
 {
   "name": "Node-FSAPI",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "server.js",
   "dependencies": {
     "restify": "~2.X.X",
+    "md5-file": "^3.1.1",
     "fs-extra": "~0.6.X"
   },
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "Node-FSAPI",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "A RESTful FileSystem API for NodeJS ",
   "dependencies": {
-    "restify": "~2.X.X",
-    "fs-extra": "~0.6.X"
+    "fs-extra": "~0.6.X",
+    "md5-file": "^3.1.1",
+    "restify": "~2.X.X"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -343,7 +343,6 @@ server.post(commandRegEx, function (req, res, next) {
         case "file":
             // Ensure base path
             if (checkPath(path)) {
-              console.log(req.params)
               if (req.params.data) {
                 fs.writeFile(path, req.params.data, function(err) {
                     if(err) {

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ var config = {
     // Port designation
     port: 8080,
     // Base directory
-    base: "example/base",
+    base: "/tmp",
     // Default create mode
     cmode: "0755"
 };
@@ -32,31 +32,32 @@ var config = {
 
 var fs = require("fs-extra"),
     restify = require("restify"),
+    md5File = require('md5-file'),
     server;
 
 // Determine if SSL is used
 if (config.ssl.key && config.ssl.cert) {
-    
+
     // Get CERT
     var https = {
         certificate: fs.readFileSync(config.ssl.cert),
         key: fs.readFileSync(config.ssl.key)
     };
-    
+
     // Config server with SSL
     server = restify.createServer({
         name: "fsapi",
         certificate: https.certificate,
         key: https.key
     });
-    
+
 } else {
-    
+
     // Config non-SSL Server
     server = restify.createServer({
         name: "fsapi"
     });
-    
+
 }
 
 // Additional server config
@@ -106,7 +107,7 @@ var checkKey = function (config, req) {
 /**
  * Check IP (Called by checkReq)
  */
- 
+
 var checkIP = function (config, req) {
     var ip = req.connection.remoteAddress.split("."),
         curIP,
@@ -127,33 +128,33 @@ var checkIP = function (config, req) {
     }
     return false;
 };
- 
+
 
 /**
  * Check Request
  * Checks Key and IP Address
  */
- 
+
 var checkReq = function (config, req, res) {
-    
+
     // Set access control headers
     res.header('Access-Control-Allow-Origin', '*');
-    
+
     // Check key and IP
     if(!checkKey(config, req) || !checkIP(config, req)) {
         res.send(401);
         return false;
     }
-    
+
     return true;
 };
 
 /**
  * Response Error
  */
- 
+
 var resError = function (code, raw, res) {
-    
+
     var codes = {
         100: "Unknown command",
         101: "Could not list files",
@@ -165,16 +166,16 @@ var resError = function (code, raw, res) {
         107: "Could not write to file",
         108: "Could not delete object"
     };
-    
+
     res.send({ "status": "error", "code": code, "message": codes[code], "raw": raw });
     return false;
-    
+
 };
 
 /**
  * Response Success
  */
- 
+
 var resSuccess = function (data, res) {
 
     res.send({ "status": "success", "data": data });
@@ -199,7 +200,7 @@ var merge = function (obj1,obj2) {
 
 var getBasePath = function (path) {
     var base_path = path.split("/");
-        
+
     base_path.pop();
     return base_path.join("/");
 };
@@ -207,7 +208,7 @@ var getBasePath = function (path) {
 /**
  * Check Path
  */
- 
+
 var checkPath = function (path) {
     var base_path = getBasePath(path);
     return fs.existsSync(base_path);
@@ -215,20 +216,20 @@ var checkPath = function (path) {
 
 /**
  * GET (Read)
- * 
+ *
  * Commands:
  * dir - list contents of directory
  * file - return content of a file
- * 
+ *
  */
 server.get(commandRegEx, function (req, res, next) {
-    
+
     // Check request
     checkReq(config, req, res);
-    
+
     // Set path
     var path = config.base + "/" + req.params[2];
-    
+
     switch (req.params[1]) {
         // List contents of directory
         case "dir":
@@ -236,10 +237,10 @@ server.get(commandRegEx, function (req, res, next) {
                 if (err) {
                     resError(101, err, res);
                 } else {
-                    
+
                     // Ensure ending slash on path
                     (path.slice(-1)!=="/") ? path = path + "/" : path = path;
-                
+
                     var output = {},
                         output_dirs = {},
                         output_files = {},
@@ -258,10 +259,10 @@ server.get(commandRegEx, function (req, res, next) {
                             link: link
                         };
                     };
-                    
+
                     // Sort alphabetically
                     files.sort();
-                    
+
                     // Loop through and create two objects
                     // 1. Directories
                     // 2. Files
@@ -272,19 +273,19 @@ server.get(commandRegEx, function (req, res, next) {
                         if (fs.lstatSync(current).isDirectory()) {
                             output_dirs[files[i]] = createItem(current,relpath,"directory",link);
                         } else {
-                            output_files[files[i]] = createItem(current,relpath,"file",link);                            
+                            output_files[files[i]] = createItem(current,relpath,"file",link);
                         }
                     }
-                    
+
                     // Merge so we end up with alphabetical directories, then files
                     output = merge(output_dirs,output_files);
-                    
+
                     // Send output
                     resSuccess(output, res);
                 }
             });
             break;
-        
+
         // Return contents of requested file
         case "file":
             fs.readFile(path, "utf8", function (err, data) {
@@ -295,7 +296,7 @@ server.get(commandRegEx, function (req, res, next) {
                 }
             });
             break;
-            
+
         default:
             // Unknown command
             resError(100, null, res);
@@ -306,26 +307,26 @@ server.get(commandRegEx, function (req, res, next) {
 
 /**
  * POST (Create)
- * 
+ *
  * Commands:
  * dir - creates a new directory
  * file - creates a new file
  * copy - copies a file or dirextory (to path at param "destination")
- * 
+ *
  */
 server.post(commandRegEx, function (req, res, next) {
-    
+
     // Check request
     checkReq(config, req, res);
-    
+
     // Set path
     var path = config.base + "/" + req.params[2];
-    
+
     switch (req.params[1]) {
-        
+
         // Creates a new directory
         case "dir":
-            
+
             // Ensure base path
             if (checkPath(path)) {
                 // Base path exists, create directory
@@ -337,20 +338,43 @@ server.post(commandRegEx, function (req, res, next) {
                 resError(103, null, res);
             }
             break;
-        
+
         // Creates a new file
         case "file":
             // Ensure base path
             if (checkPath(path)) {
-                // Base path exists, create file
+              console.log(req.params)
+              if (req.params.data) {
+                fs.writeFile(path, req.params.data, function(err) {
+                    if(err) {
+                        resError(107, err, res);
+                    } else {
+                        resSuccess(null, res);
+                    }
+                });
+              } else if (req.files && req.files.filedata) {
+                fs.readFile(req.files.filedata.path, function (err, data) {
+                    fs.writeFile(path, data, function (err) {
+                      if(err) {
+                          resError(107, err, res);
+                      } else {
+                          var hash = md5File.sync(path)
+                          resSuccess(hash, res);
+                      }
+                    });
+                });
+              } else {
+                // No file attached, Base path exists, create empty file
                 fs.openSync(path, "w");
                 resSuccess(null, res);
+                resError(106, null, res);
+              }
             } else {
                 // Bad base path
                 resError(103, null, res);
             }
             break;
-        
+
         // Copies a file or directory
         // Supply destination as full path with file or folder name at end
         // Ex: http://yourserver.com/{key}/copy/folder_a/somefile.txt, destination: /folder_b/somefile.txt
@@ -370,89 +394,103 @@ server.post(commandRegEx, function (req, res, next) {
                 resError(103, null, res);
             }
             break;
-            
+
         default:
             // Unknown command
             resError(100, null, res);
     }
-    
+
     return next();
 });
 
 /**
  * PUT (Update)
- * 
+ *
  * Commands:
  * rename - renames a file or folder (using param "name")
  * save - saves contents to a file (using param "data")
- * 
+ *
  */
 server.put(commandRegEx, function (req, res, next) {
-    
+
     // Check request
     checkReq(config, req, res);
-    
+
     // Set path
     var path = config.base + "/" + req.params[2];
-    
+
     switch (req.params[1]) {
-        
+
         // Rename a file or directory
         case "rename":
-            
+
             var base_path = getBasePath(path);
-            
+
             fs.rename(path,base_path + "/" + req.params.name, function () {
                 resSuccess(null, res);
             });
-            
+
             break;
-        
+
         // Saves contents to a file
-        case "save":
-            
+        case "file":
             // Make sure it exists
             if (fs.existsSync(path)) {
                 // Make sure it's a file
                 if (!fs.lstatSync(path).isDirectory()) {
                     // Write
-                    fs.writeFile(path, req.params.data, function(err) {
-                        if(err) {
-                            resError(107, err, res);
-                        } else {
-                            resSuccess(null, res);
-                        }
-                    });
+                    if (req.params.data) {
+                      fs.writeFile(path, req.params.data, function(err) {
+                          if(err) {
+                              resError(107, err, res);
+                          } else {
+                              resSuccess(null, res);
+                          }
+                      });
+                    } else if (req.files && req.files.filedata) {
+                      fs.readFile(req.files.filedata.path, function (err, data) {
+                          fs.writeFile(path, data, function (err) {
+                            if(err) {
+                                resError(107, err, res);
+                            } else {
+                                var hash = md5File.sync(path)
+                                resSuccess(hash, res);
+                            }
+                          });
+                      });
+                    } else {
+                      resError(106, null, res);
+                    }
                 } else {
                     resError(106, null, res);
                 }
             } else {
                 resError(105, null, res);
             }
-            
+
             break;
-        
-            
+
+
         default:
             // Unknown command
             resError(100, null, res);
     }
-    
+
     return next();
-    
+
 });
 
 /**
- * DELETE 
+ * DELETE
  */
 server.del(pathRegEx, function (req, res, next) {
-    
+
     // Check request
     checkReq(config, req, res);
-    
+
     // Set path
     var path = config.base + "/" + req.params[1];
-    
+
     // Make sure it exists
     if (fs.existsSync(path)) {
         // Remove file or directory
@@ -466,9 +504,9 @@ server.del(pathRegEx, function (req, res, next) {
     } else {
         resError(103, null, res);
     }
-    
+
     return next();
-    
+
 });
 
 /**


### PR DESCRIPTION
add support for file saving, add return of MD5 hash, add examples to
documentation, normalize URL (file vs. save), add example of install
without dtrace for MacOS.